### PR TITLE
pinned flake compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache/
 zig-out/
+/result*

--- a/flake.lock
+++ b/flake.lock
@@ -94,13 +94,13 @@
       "locked": {
         "lastModified": 1642206480,
         "narHash": "sha256-aS5zbhz+KXmDYBINbEabnVEhp7OQ0yR/O7pfFZqKRPw=",
-        "owner": "arqv",
+        "owner": "roarkanize",
         "repo": "zig-overlay",
         "rev": "78e7670a7e1d57a60819dc1bfa026670bf09c48c",
         "type": "github"
       },
       "original": {
-        "owner": "arqv",
+        "owner": "roarkanize",
         "repo": "zig-overlay",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -64,6 +80,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "zig": "zig"

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,8 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     zig.url = "github:arqv/zig-overlay";
+
+    flake-compat = { url = github:edolstra/flake-compat; flake = false; };
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }@inputs:

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    zig.url = "github:arqv/zig-overlay";
+    zig.url = "github:roarkanize/zig-overlay";
 
     flake-compat = { url = github:edolstra/flake-compat; flake = false; };
   };

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,9 @@
-(
-  import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-    src = builtins.fetchGit ./.;
-  }
-).shellNix
+(import
+  (
+    let flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat; in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+      sha256 = flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }).shellNix


### PR DESCRIPTION
Just these bits from #1:

- pin flake-compat via the flake
- ignore nix build results
- update zig-overlay owner/user
